### PR TITLE
fix: Optimize web font loading with next/font

### DIFF
--- a/src/app/global.scss
+++ b/src/app/global.scss
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Kaisei+Decol:wght@400;500;700&display=swap');
-@import url('https://use.typekit.net/ebk1gqb.css');
-
 :root {
   font-size: 16px;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,14 @@ import './global.scss'
 import RootStyleRegistry from './emotion'
 import { FirebaseProvider } from './firebase'
 import { firebaseConfig, inactivateAnalytics } from '@/config'
+import { Kaisei_Decol } from 'next/font/google'
+
+const kaiseiDecol = Kaisei_Decol({
+  weight: ['400', '500', '700'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-kaisei-decol',
+})
 
 export const metadata = {
   title: 'Pon Pon Creamsoda',
@@ -18,7 +26,10 @@ type RootLayoutProps = {
 
 export default function RootLayout({ children }: RootLayoutProps): React.ReactElement {
   return (
-    <html lang="ja">
+    <html lang="ja" className={kaiseiDecol.variable}>
+      <head>
+        <link rel="stylesheet" href="https://use.typekit.net/ebk1gqb.css" />
+      </head>
       <body>
         <RootStyleRegistry>
           <FirebaseProvider config={firebaseConfig} inactivateAnalytics={inactivateAnalytics}>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -10,7 +10,7 @@ const breakpoints = {
 const styles = {
   text: css`
     letter-spacing: 0.05em;
-    font-family: 'Kaisei Decol', serif;
+    font-family: var(--font-kaisei-decol), 'Kaisei Decol', serif;
     line-height: 1.3;
   `,
   textMenu: css`


### PR DESCRIPTION
## Summary
- Replace CSS @import with next/font/google for Kaisei Decol
- Use direct link tag for Adobe Fonts
- Fix font loading issues in production builds

## Changes
- Optimize Kaisei Decol with next/font/google for self-hosting
- Load Adobe Fonts via link tag instead of @import
- Remove broken @import from global.scss

🤖 Generated with [Claude Code](https://claude.com/claude-code)